### PR TITLE
Update tmus-geo-ip.txt

### DIFF
--- a/tmus-geo-ip.txt
+++ b/tmus-geo-ip.txt
@@ -1,9 +1,9 @@
 # T-Mobile US Geofeed,lastupdated (rfc3339): 2020-11-17T12:12:27-08:00
 # Self-published geofeed as defined in datatracker.ietf.org/doc/html/rfc8805
-172.32.0.0/11,US,,,
-208.54.0.0/17,US,,,
-208.54.128.0/19,US,,,
-2607:FB90::/28,US,,,
+172.32.0.0/11,US,Washington,Factoria,Bellevue,98006
+208.54.0.0/17,US,Washington,Factoria,Bellevue,98006
+208.54.128.0/19,US,Washington,Factoria,Bellevue,98006
+2607:FB90::/28,US,Washington,Factoria,Bellevue,98006
 2607:fb90:ae00::/44,US,US-AL,Birmingham,
 2607:fb90:ae10::/44,US,US-AL,Birmingham,
 2607:fb90:ae20::/44,US,US-AL,Birmingham,


### PR DESCRIPTION
Setting headquarters address as default address for the entries where the location is empty.